### PR TITLE
#25: Add dynamic version detection & generally make things nicer/better

### DIFF
--- a/zwo_fixer/Makefile
+++ b/zwo_fixer/Makefile
@@ -4,21 +4,6 @@ SHELL:=/bin/bash
 CXXFLAGS:=-std=c++17 -fno-exceptions -fno-strict-aliasing -D_GLIBCXX_USE_CXX11_ABI=0 -fdiagnostics-color=always -Wall -Wno-unused-variable -Wno-unused-function -O1 -fuse-linker-plugin -fvisibility=hidden -fvisibility-inlines-hidden -g3 -gdwarf-4 -fvar-tracking-assignments -fno-omit-frame-pointer -fuse-ld=gold -shared -fPIC -fno-plt -fno-gnu-unique -rdynamic -Wl,--no-gc-sections -Wl,--no-undefined -Wl,-z,defs -lbsd -ldl -lelf -lusb-1.0
 
 
-# omit leading zeroes or else face the wrath of octal interpretation
-ZWO_VERSION_MAJOR   :=1
-ZWO_VERSION_MINOR   :=14
-ZWO_VERSION_REVISION:=715
-
-ZWO_VERSION_STRING:=$(shell printf "%u.%u.%04u"     $(ZWO_VERSION_MAJOR) $(ZWO_VERSION_MINOR) $(ZWO_VERSION_REVISION))
-ZWO_VERSION       :=$(shell printf "0x%02u%02u%04u" $(ZWO_VERSION_MAJOR) $(ZWO_VERSION_MINOR) $(ZWO_VERSION_REVISION))
-
-CXXFLAGS+=-DZWO_VERSION_MAJOR=$(ZWO_VERSION_MAJOR)
-CXXFLAGS+=-DZWO_VERSION_MINOR=$(ZWO_VERSION_MINOR)
-CXXFLAGS+=-DZWO_VERSION_REVISION=$(ZWO_VERSION_REVISION)
-CXXFLAGS+=-DZWO_VERSION_STRING=\"$(ZWO_VERSION_STRING)\"
-CXXFLAGS+=-DZWO_VERSION=$(ZWO_VERSION)U
-
-
 .PHONY: all clean
 
 all: libzwo_fixer.so

--- a/zwo_fixer/zwo_fixer.cpp
+++ b/zwo_fixer/zwo_fixer.cpp
@@ -4,35 +4,35 @@
 
 // PLT hooks ===================================================================
 
-// proof-of-concept hook
-// also potentially useful for doing the buf3_ptr libusb_dev_mem_alloc/libusb_dev_mem_free thing
-// (though upon further consideration we'd want to do the buf3_ptr switcheroo somewhere else)
-#if 0
-PLTHook plthook__libusb_open(
-	"libusb_open",
-	libASICamera2_PLT__libusb_open,
-	+[](libusb_device *dev, libusb_device_handle **handle) -> int {
-		Msg(Color::MAGENTA, "PLTHook(libusb_open): entry: dev = 0x%016" PRIX64 " *handle = 0x%016" PRIX64 "\n",
-			(uint64_t)dev, (uint64_t)(*handle));
-		
-		uint8_t dev_bus              = libusb_get_bus_number(dev);
-		uint8_t dev_port             = libusb_get_port_number(dev);
-		uint8_t dev_addr             = libusb_get_device_address(dev);
-		int dev_speed                = libusb_get_device_speed(dev);
-		int dev_max_packet_size_0x81 = libusb_get_max_packet_size(dev, 0x81);
-		
-		Msg(Color::MAGENTA, "PLTHook(libusb_open): pre: bus %d port %d addr %d speed %d maxpktsize %d\n",
-			dev_bus, dev_port, dev_addr, dev_speed, dev_max_packet_size_0x81);
-		
-		int retval = libusb_open(dev, handle);
-		
-		Msg(Color::MAGENTA, "PLTHook(libusb_open): exit: retval = %d *handle = 0x%016" PRIX64 "\n",
-			retval, (uint64_t)(*handle));
-		
-		return retval;
-	}
-);
-#endif
+
+/*
+- hook CCameraFX3::startAsyncXfer so we can figure out what the hell the two timeout_ms values actually are being calculated as...
+
+when -EOVERFLOW happens:
+- the callbackUSBTransferComplete callback function should (AFAIK) get transfer->status == LIBUSB_TRANSFER_OVERFLOW (6)
+  - maybe add a hook that prints a useful error message when it gets that status value or something
+    - can't do this directly with a PLT hook; instead, just make a wrapper callback func around
+      callbackUSBTransferComplete and use a PLT hook for libusb_submit_transfer to substitute our func ptr for the
+      xfer->callback member
+*/
+
+
+// libusb_open:
+// via libusb_open_device_with_vid_pid_index
+// via CCameraBase::OpenCamera
+// via the vtable...
+
+// libusb_close:
+// via CCameraFX3::CloseDevice
+// via CCameraBase::CloseCam
+// via CCameraS178MC dtor (before CCameraBase dtor)
+
+
+// unsigned char *libusb_dev_mem_alloc(libusb_device_handle *dev_handle, size_t length)
+// - returns NULL on failure
+
+// int libusb_dev_mem_free(libusb_device_handle *dev_handle, unsigned char *buffer, size_t length)
+// - returns LIBUSB_SUCCESS on success
 
 
 // ZWO is too stupid to bother checking the return values of basically any of the libusb functions they call;
@@ -50,16 +50,16 @@ PLTHook plthook__libusb_open(
 // This fixes that idiocy.
 PLTHook plthook__libusb_cancel_transfer(
 	"libusb_cancel_transfer",
-	libASICamera2_PLT__libusb_cancel_transfer,
-	+[](struct libusb_transfer *transfer) -> int {
+	GetAddr(".plt:libusb_cancel_transfer"),
+	+[](libusb_transfer *transfer) -> int {
 		int retval = libusb_cancel_transfer(transfer);
 		
 		// falsify some variables so that CCameraFX3::startAsyncXfer will think that
 		// callbackUSBTransferComplete *did* get called but had some kind of problem
 		if (retval == LIBUSB_ERROR_NOT_FOUND) {
 			Msg(Color::GREEN, "PLTHook(libusb_cancel_transfer): got LIBUSB_ERROR_NOT_FOUND; fixing broken code\n");
-			*lin_XferLen        = -1;
-			*lin_XferCallbacked = true;
+			lin_XferLen        = -1;
+			lin_XferCallbacked = true;
 		} else {
 //			Msg(Color::YELLOW, "PLTHook(libusb_cancel_transfer): got %s; ignoring\n", libusb_strerror(retval));
 		}
@@ -67,23 +67,6 @@ PLTHook plthook__libusb_cancel_transfer(
 		return retval;
 	}
 );
-
-
-
-/*
-
-- hook CCameraFX3::startAsyncXfer so we can figure out what the hell the two timeout_ms values actually are being calculated as...
-
-when -EOVERFLOW happens:
-- the callbackUSBTransferComplete callback function should (AFAIK) get transfer->status == LIBUSB_TRANSFER_OVERFLOW (6)
-  - maybe add a hook that prints a useful error message when it gets that status value or something
-    - can't do this directly with a PLT hook; instead, just make a wrapper callback func around
-      callbackUSBTransferComplete and use a PLT hook for libusb_submit_transfer to substitute our func ptr for the
-      xfer->callback member
-
-*/
-
-
 
 // =============================================================================
 
@@ -105,40 +88,11 @@ static void ZWOFixerExit()
 extern "C" [[gnu::visibility("default")]]
 bool ZWOFixerInit()
 {
-//	Msg(Color::WHITE, "ZWOFixerInit: installing PLT hook for libusb_open...\n");
-//	plthook__libusb_open.Install();
-//	Msg(Color::WHITE, "ZWOFixerInit: installed  PLT hook for libusb_open.\n");
-	
-#if 0
-	void *dl_handle = nullptr;
-	assert((dl_handle = dlopen("libASICamera2.so." ZWO_VERSION_STRING, RTLD_NOW | RTLD_NOLOAD)) != nullptr);
-	// ...
-	assert(dlclose(dl_handle) == 0);
-#endif
-	
 	atexit(&ZWOFixerExit);
 	
-	Msg(Color::WHITE, "ZWOFixerInit: %s\n", (g_Fail ? "FAIL" : "OK"));
-	return !g_Fail;
+	bool ok = IsLibASILoadedAndSupported();
+	Msg((ok ? Color::GREEN : Color::RED), "ZWOFixerInit: %s\n", (ok ? "OK" : "FAIL"));
+	return ok;
 }
 
 // =============================================================================
-
-
-
-// libusb_open:
-// via libusb_open_device_with_vid_pid_index
-// via CCameraBase::OpenCamera
-// via the vtable...
-
-// libusb_close:
-// via CCameraFX3::CloseDevice
-// via CCameraBase::CloseCam
-// via CCameraS178MC dtor (before CCameraBase dtor)
-
-
-// unsigned char *libusb_dev_mem_alloc(libusb_device_handle *dev_handle, size_t length)
-// - returns NULL on failure
-
-// int libusb_dev_mem_free(libusb_device_handle *dev_handle, unsigned char *buffer, size_t length)
-// - returns LIBUSB_SUCCESS on success

--- a/zwo_fixer/zwo_fixer.hpp
+++ b/zwo_fixer/zwo_fixer.hpp
@@ -7,6 +7,8 @@
 extern "C"
 {
 	// Call this BEFORE calling any ZWO API functions!
+	// Call this AFTER loading the ZWO shared library!
+	//   (if you are opening it with dlopen rather than linking to it directly)
 	// Returns true if fixes were able to be applied successfully
 	// Returns false if there were problems applying some of the fixes
 	bool ZWOFixerInit();


### PR DESCRIPTION
This is a large refactoring of `zwo_fixer`, and it really cleans things up, in my opinion.

Most notably, the ASI SDK version configuration is no longer statically determined at compile-time by the Makefile. Instead, at runtime, the code detects the ASI library in memory; determines its version; checks if that version is known and supported; and then proceeds to use the appropriate offsets for that particular version.

I changed a huge chunk of how the initialization code works, so this definitely needs some real testing to ensure that I didn't break anything horribly. Ideally it should be compiled once, and then tested against two different versions of `capture` (one linked against ASI 0.7.0503, and one linked against ASI 1.14.0715). Ideally it should handle the two different ASI SDK versions without any issues.