### PR TITLE
Implement camera selection logic in 'capture' program

### DIFF
--- a/capture/include/camera.h
+++ b/capture/include/camera.h
@@ -10,6 +10,6 @@ namespace camera
     constexpr int EXPOSURE_MIN_US = 32; // 32 is the minimum value for this camera
     constexpr int EXPOSURE_MAX_US = 16'667; // Max for ~60 FPS
 
-    void init_camera(ASI_CAMERA_INFO &CamInfo);
+    void init_camera(ASI_CAMERA_INFO &CamInfo, const char *cam_name);
     void run_camera(ASI_CAMERA_INFO &CamInfo);
 }

--- a/capture/src/capture.cpp
+++ b/capture/src/capture.cpp
@@ -84,11 +84,24 @@ int main(int argc, char *argv[])
 
     const char *cam_name = nullptr;
     const char *filename = nullptr;
-    for (int i = 1; i < argc; ++i) {
-        if (strncmp(argv[i], "camera=", 7) == 0) {
+    for (int i = 1; i < argc; ++i)
+    {
+        if (strncmp(argv[i], "camera=", 7) == 0)
+        {
             cam_name = argv[i] + 7;
-        } else if (strncmp(argv[i], "file=", 5) == 0) {
+        }
+        else if (strncmp(argv[i], "file=", 5) == 0)
+        {
             filename = argv[i] + 5;
+        }
+        else
+        {
+            errx(
+                1,
+                "Error: Program option '%s' not recognized\n"
+                "Usage: %s file=[output_filename.ser] camera=[camera name]",
+                argv[i], argv[0]
+            );
         }
     }
 


### PR DESCRIPTION
This isn't really a super-polished thing, to be honest. But it's probably good enough to test at this point to see if it works properly.

Basically: the program now takes potentially multiple arguments, one of which is a camera name. The camera initialization code will iterate over all connected cameras and check whether the given string is a case-insensitive substring of each connected camera's name. If there is exactly one such match, then that camera is selected for use. If there are zero or multiple matches, then the program exits with an error.

If the user doesn't specify a camera argument when running the program, then the camera initialization code will still just arbitrarily pick the first camera index and run with that. (Thinking about it, this should probably actually be an error condition... the user should have to explicitly say they want "any" camera to get this behavior.)

Things to note about this PR as it currently stands:
- I haven't actually tested it myself. It does compile though.
- The way I did command line arguments is ugly and stupid, because I was lazy. Probably I should go back and redo it with an actual argument-parsing system like `getopt` or `boost::program_options` or whatever.
- As I was writing this code, I realized that there are actually two different APIs of potential interest for identifying *particular cameras* rather than *particular camera models*. There's `ASIGetSerialNumber`, which I remembered, and which I don't recall working with the S178Mx cameras. But then there's *also* `ASIGetID` (along with `ASISetID`), which apparently read from (and write to) SPI flash. And I'm not sure whether those APIs will work with our cameras. So that needs to be looked into.