### PR TITLE
Fix incorrect syntax in SWIG bindings setup.py python_requires directive

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -38,7 +38,7 @@ setup(
 
     keywords='astronomy telescopes zwo asi',
 
-    python_requires='python>=3.6',
+    python_requires='>=3.6',
 
     install_requires=[
         'numpy',


### PR DESCRIPTION
I did the ones in point and track correctly, but somehow did this one wrong. So setup.py refused to run. D'oh.