### PR TITLE
Assign meaningful thread names in capture program

### DIFF
--- a/capture/src/capture.cpp
+++ b/capture/src/capture.cpp
@@ -58,7 +58,7 @@ static void set_thread_priority(pthread_t thread, int policy, int priority)
 {
     sched_param sch_params;
     sch_params.sched_priority = priority;
-    if (pthread_setschedparam(thread, policy, &sch_params))
+    if ((errno = pthread_setschedparam(thread, policy, &sch_params)))
     {
         err(1, "Failed to set thread priority");
     }


### PR DESCRIPTION
This PR also fixes a minor mistake regarding `libpthread` and `errno`.