### PR TITLE
#50: Add architecture detection, and ARMv8 support, to zwo_fixer's PLT hooking functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The following libraries are required for building the `capture` program (Debian 
 - libopencv-imgproc (libopencv-imgproc-dev)
 - libzwo_fixer -- built from the source contained in this repository
 
-Once the dependencies are installed, simply run `make` in the `capture/` subdirectory. This should generate a binary `capture/bin/capture`.
+Once the dependencies are installed, run `make PLATFORM=x64` in the `capture/` subdirectory. This should generate a binary `capture/bin/capture`. (To build for 32-bit x86, use `PLATFORM=x86`; for ARM, set `PLATFORM` to `armv5`/`armv6`/`armv7`/`armv8` as appropriate. This is an ugly Makefile detail that will hopefully be removed at some point.)
 
 ## Enabling Realtime Priorities for Non-Root Users
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ To compile this software, a C++ compiler is required. On Debian-based Linux dist
 The following libraries are required for building the `capture` program (Debian package names in parentheses):
 - librt (libc6-dev)
 - libpthread (libc6-dev)
+- libbsd (libbsd-dev)
 - libusb-1.0 (libusb-1.0-0-dev)
 - libopencv-core (libopencv-core-dev)
 - libopencv-highgui (libopencv-highgui-dev)

--- a/capture/Makefile
+++ b/capture/Makefile
@@ -14,9 +14,10 @@ CC = g++
 OPENCV = -lopencv_core -lopencv_highgui -lopencv_imgproc#$(shell pkg-config --cflags opencv) $(shell pkg-config --libs opencv) -I/usr/include/opencv2
 USB = -I../libusb/include  -L../libusb/$(PLATFORM) -lusb-1.0
 
-
 # "hack" for compat with Arch Linux's opencv include path, since we aren't using pkg-config in here for some idiotic reason
 OPENCV += -I/usr/include/opencv4
+
+LIBS = -lrt -lbsd
 
 
 ASI_VERSION = 1.16.3
@@ -27,7 +28,7 @@ ASI_INCPATH  = $(ASI_BASEPATH)/include
 ASI_LIBPATH  = $(ASI_BASEPATH)/lib/$(PLATFORM)
 
 ASI_CFLAGS  = -I$(ASI_INCPATH)
-ASI_LDFLAGS = -L$(ASI_LIBPATH) -lrt -l:libASICamera2.so.$(ASI_VERSION)
+ASI_LDFLAGS = -L$(ASI_LIBPATH) -l:libASICamera2.so.$(ASI_VERSION)
 
 
 ZWOFIXER_PATH=../zwo_fixer
@@ -79,11 +80,11 @@ all: bin/capture bin/write_benchmark
 bin/capture: src/Frame.cpp src/SERFile.cpp src/agc.cpp src/disk.cpp src/preview.cpp src/camera.cpp src/capture.cpp
 	make -C $(ZWOFIXER_PATH) all
 	mkdir -p bin
-	$(CC) $^ -o $@ $(CFLAGS) $(OPENCV) $(ASI_CFLAGS) $(ASI_LDFLAGS) $(ZWOFIXER_CFLAGS) $(ZWOFIXER_LDFLAGS)
+	$(CC) $^ -o $@ $(CFLAGS) $(LIBS) $(OPENCV) $(ASI_CFLAGS) $(ASI_LDFLAGS) $(ZWOFIXER_CFLAGS) $(ZWOFIXER_LDFLAGS)
 
 bin/write_benchmark: write_benchmark.cpp
 	mkdir -p bin
-	$(CC) $< -o $@ $(CFLAGS)
+	$(CC) $< -o $@ $(CFLAGS) $(LIBS)
 
 clean:
 	make -C $(ZWOFIXER_PATH) clean

--- a/capture/Makefile
+++ b/capture/Makefile
@@ -1,7 +1,12 @@
 #VERSION = debug
  VERSION = release
 
-PLATFORM = x64
+#PLATFORM = x86
+ PLATFORM = x64
+#PLATFORM = armv5
+#PLATFORM = armv6
+#PLATFORM = armv7
+#PLATFORM = armv8
 
 
 CC = g++
@@ -22,7 +27,7 @@ ASI_INCPATH  = $(ASI_BASEPATH)/include
 ASI_LIBPATH  = $(ASI_BASEPATH)/lib/$(PLATFORM)
 
 ASI_CFLAGS  = -I$(ASI_INCPATH)
-ASI_LDFLAGS = -L$(ASI_LIBPATH) -l:libASICamera2.so.$(ASI_VERSION)
+ASI_LDFLAGS = -L$(ASI_LIBPATH) -lrt -l:libASICamera2.so.$(ASI_VERSION)
 
 
 ZWOFIXER_PATH=../zwo_fixer
@@ -41,9 +46,31 @@ else
 	CFLAGS += -O3
 endif
 
+ifeq ($(PLATFORM), x86)
+	CFLAGS += -m32
+endif
+
 ifeq ($(PLATFORM), x64)
 	CFLAGS += -m64
-	CFLAGS += -lrt
+endif
+
+ifeq ($(PLATFORM), armv5)
+#	CC      = arm-none-linux-gnueabi-g++
+	CFLAGS += -march=armv5
+endif
+
+ifeq ($(PLATFORM), armv6)
+#	CC      = arm-linux-gnueabi-g++
+	CFLAGS += -march=armv6
+endif
+
+ifeq ($(PLATFORM), armv7)
+#	CC      = arm-linux-gnueabihf-g++
+	CFLAGS += -march=armv7 -mcpu=cortex-m3 -mthumb
+endif
+
+ifeq ($(PLATFORM), armv8)
+#	CC = aarch64-linux-gnu-g++
 endif
 
 

--- a/capture/include/SERFile.h
+++ b/capture/include/SERFile.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <cstring>
 #include <vector>
 #include "Frame.h"
 
@@ -54,19 +55,26 @@ struct __attribute__ ((packed)) SERHeader_t
     int32_t FrameCount = 0;
 
     // 9. Name of observer. 40 ASCII characters {32-126 dec.}, fill unused characters with 0 dec.
-    char Observer[40] = "";
+    char Observer[40];
 
     // 10. Name of used camera. 40 ASCII characters {32-126 dec.}, fill unused characters with 0 dec.
-    char Instrument[40] = "";
+    char Instrument[40];
 
     // 11. Name of used telescope. 40 ASCII characters {32-126 dec.}, fill unused characters with 0 dec.
-    char Telescope[40] = "";
+    char Telescope[40];
 
     // 12. Start time of image stream (local time). Must be >= 0.
     int64_t DateTime = 0;
 
     // 13. Start time of image stream in UTC.
     int64_t DateTime_UTC = 0;
+
+	SERHeader_t() noexcept
+	{
+		memset(Observer,   0, sizeof(Observer));
+		memset(Instrument, 0, sizeof(Instrument));
+		memset(Telescope,  0, sizeof(Telescope));
+	}
 };
 
 

--- a/capture/include/SERFile.h
+++ b/capture/include/SERFile.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstring>
+#include <tuple>
 #include <vector>
 #include "Frame.h"
 
@@ -28,7 +29,7 @@ enum SERColorID_t : int32_t
 };
 
 
-struct __attribute__ ((packed)) SERHeader_t
+struct [[gnu::packed]] SERHeader_t
 {
     // 1. This is a historical artifact of the SER format.
     const char FileID[14] = {'L', 'U', 'C', 'A', 'M', '-', 'R', 'E', 'C', 'O', 'R', 'D', 'E', 'R'};
@@ -112,5 +113,6 @@ private:
     bool add_trailer_;
     std::vector<int64_t> frame_timestamps_;
 
-    void makeTimestamps(int64_t *utc, int64_t *local);
+    using TimestampPair_t = std::tuple<int64_t, int64_t>; // utc, local
+    TimestampPair_t makeTimestamps();
 };

--- a/capture/src/SERFile.cpp
+++ b/capture/src/SERFile.cpp
@@ -1,5 +1,5 @@
 #include "SERFile.h"
-#include <cstring>
+#include <bsd/string.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/mman.h>
@@ -71,9 +71,9 @@ SERFile::SERFile(
     header_->ImageHeight = height;
     header_->ColorID = color_id;
     header_->PixelDepthPerPlane = bit_depth;
-    strncpy(header_->Observer, observer, 40);
-    strncpy(header_->Instrument, instrument, 40);
-    strncpy(header_->Telescope, telescope, 40);
+    strlcpy(header_->Observer, observer, 40);
+    strlcpy(header_->Instrument, instrument, 40);
+    strlcpy(header_->Telescope, telescope, 40);
     makeTimestamps(&(header_->DateTime_UTC), &(header_->DateTime));
 }
 

--- a/zwo_fixer/internal.hpp
+++ b/zwo_fixer/internal.hpp
@@ -17,7 +17,7 @@
 // Linux    ARMv5  UNSUPPORTED (maybe later)
 // Linux    ARMv6  UNSUPPORTED (maybe later)
 // Linux    ARMv7  UNSUPPORTED (maybe later)
-// Linux    ARMv8  UNSUPPORTED (soon)
+// Linux    ARMv8    SUPPORTED
 // Windows  x86    UNSUPPORTED (probably never)
 // Windows  x64    UNSUPPORTED (probably never)
 // MacOS    x86    UNSUPPORTED (probably never)
@@ -45,8 +45,7 @@
 		#warning functionality will be disabled!
 	#elif defined(__aarch64__) && defined(__ARM_ARCH) && __ARM_ARCH == 8
 		#define FIXER_ARMV8     1
-		#warning zwo_fixer does not support the ARMv8 architecture (yet)!
-		#warning functionality will be disabled!
+		#define FIXER_SUPPORTED 1
 	#else
 		#error zwo_fixer does not support whatever CPU architecture this is!
 	#endif
@@ -172,6 +171,11 @@ static const OffsetMap_t g_Offsets_v1_16_3 = {
 	{ ".got.plt:libusb_cancel_transfer",   0x3DECB0 },
 	{ ".data:lin_XferLen",                 0x3E7580 },
 	{ ".bss:lin_XferCallbacked",           0x437D14 },
+#elif FIXER_ARMV8
+	{ ".text:callbackUSBTransferComplete", 0x1664A0 },
+	{ ".got.plt:libusb_cancel_transfer",   0x1D44C0 },
+	{ ".data:lin_XferLen",                 0x1DB7F0 },
+	{ ".bss:lin_XferCallbacked",           0x238B00 },
 #endif
 };
 
@@ -191,6 +195,11 @@ static const OffsetMap_t g_Offsets_v1_14_1119 = {
 	{ ".got.plt:libusb_cancel_transfer",   0x3993D0 },
 	{ ".data:lin_XferLen",                 0x3A1540 },
 	{ ".bss:lin_XferCallbacked",           0x3F1B74 },
+#elif FIXER_ARMV8
+	{ ".text:callbackUSBTransferComplete", 0x135760 },
+	{ ".got.plt:libusb_cancel_transfer",   0x193FB0 },
+	{ ".data:lin_XferLen",                 0x19ACF0 },
+	{ ".bss:lin_XferCallbacked",           0x1F7EF0 },
 #endif
 };
 
@@ -388,6 +397,11 @@ private:
 #if FIXER_X64
 	static constexpr size_t PLT_ENTRY_SIZE     = 16;
 	static constexpr size_t PLT_ENTRY_ALIGN    =  4;
+	static constexpr size_t GOT_PLT_SLOT_SIZE  =  8;
+	static constexpr size_t GOT_PLT_SLOT_ALIGN =  8;
+#elif FIXER_ARMV8
+	static constexpr size_t PLT_ENTRY_SIZE     = 16;
+	static constexpr size_t PLT_ENTRY_ALIGN    = 16;
 	static constexpr size_t GOT_PLT_SLOT_SIZE  =  8;
 	static constexpr size_t GOT_PLT_SLOT_ALIGN =  8;
 #endif

--- a/zwo_fixer/internal.hpp
+++ b/zwo_fixer/internal.hpp
@@ -16,8 +16,8 @@
 // Linux    x64      SUPPORTED
 // Linux    ARMv5  UNSUPPORTED (maybe later)
 // Linux    ARMv6  UNSUPPORTED (maybe later)
-// Linux    ARMv7  UNSUPPORTED (maybe later)
-// Linux    ARMv8    SUPPORTED
+// Linux    ARMv7    SUPPORTED (untested; Thumb mode transitions are evil)
+// Linux    ARMv8    SUPPORTED (untested)
 // Windows  x86    UNSUPPORTED (probably never)
 // Windows  x64    UNSUPPORTED (probably never)
 // MacOS    x86    UNSUPPORTED (probably never)
@@ -41,8 +41,7 @@
 		#warning functionality will be disabled!
 	#elif defined(__arm__) && defined(__ARM_ARCH) && __ARM_ARCH == 7
 		#define FIXER_ARMV7 1
-		#warning zwo_fixer does not support the ARMv7 architecture (yet)!
-		#warning functionality will be disabled!
+		#define FIXER_SUPPORTED 1
 	#elif defined(__aarch64__) && defined(__ARM_ARCH) && __ARM_ARCH == 8
 		#define FIXER_ARMV8     1
 		#define FIXER_SUPPORTED 1
@@ -171,6 +170,11 @@ static const OffsetMap_t g_Offsets_v1_16_3 = {
 	{ ".got.plt:libusb_cancel_transfer",   0x3DECB0 },
 	{ ".data:lin_XferLen",                 0x3E7580 },
 	{ ".bss:lin_XferCallbacked",           0x437D14 },
+#elif FIXER_ARMV7
+	{ ".text:callbackUSBTransferComplete", 0x10E498 },
+	{ ".got.plt:libusb_cancel_transfer",   0x13B964 }, // actually in .got (there is no .got.plt)
+	{ ".data:lin_XferLen",                 0x141234 },
+	{ ".bss:lin_XferCallbacked",           0x181DF0 },
 #elif FIXER_ARMV8
 	{ ".text:callbackUSBTransferComplete", 0x1664A0 },
 	{ ".got.plt:libusb_cancel_transfer",   0x1D44C0 },
@@ -195,6 +199,11 @@ static const OffsetMap_t g_Offsets_v1_14_1119 = {
 	{ ".got.plt:libusb_cancel_transfer",   0x3993D0 },
 	{ ".data:lin_XferLen",                 0x3A1540 },
 	{ ".bss:lin_XferCallbacked",           0x3F1B74 },
+#elif FIXER_ARMV7
+	{ ".text:callbackUSBTransferComplete", 0x0E8118 },
+	{ ".got.plt:libusb_cancel_transfer",   0x11460C }, // actually in .got (there is no .got.plt)
+	{ ".data:lin_XferLen",                 0x119C10 },
+	{ ".bss:lin_XferCallbacked",           0x15A740 },
 #elif FIXER_ARMV8
 	{ ".text:callbackUSBTransferComplete", 0x135760 },
 	{ ".got.plt:libusb_cancel_transfer",   0x193FB0 },
@@ -399,6 +408,11 @@ private:
 	static constexpr size_t PLT_ENTRY_ALIGN    =  4;
 	static constexpr size_t GOT_PLT_SLOT_SIZE  =  8;
 	static constexpr size_t GOT_PLT_SLOT_ALIGN =  8;
+#elif FIXER_ARMV7
+	static constexpr size_t PLT_ENTRY_SIZE     = 12;
+	static constexpr size_t PLT_ENTRY_ALIGN    =  4;
+	static constexpr size_t GOT_PLT_SLOT_SIZE  =  4;
+	static constexpr size_t GOT_PLT_SLOT_ALIGN =  4;
 #elif FIXER_ARMV8
 	static constexpr size_t PLT_ENTRY_SIZE     = 16;
 	static constexpr size_t PLT_ENTRY_ALIGN    = 16;

--- a/zwo_fixer/internal.hpp
+++ b/zwo_fixer/internal.hpp
@@ -118,6 +118,16 @@ static const OffsetMap_t g_Offsets_v1_16_3 = {
 	{ ".bss:lin_XferCallbacked",           0x437D14 },
 };
 
+static const OffsetMap_t g_Offsets_v1_16_2;
+static const OffsetMap_t g_Offsets_v1_16_1;
+static const OffsetMap_t g_Offsets_v1_16_0;
+static const OffsetMap_t g_Offsets_v1_15_0915;
+static const OffsetMap_t g_Offsets_v1_15_0819;
+static const OffsetMap_t g_Offsets_v1_15_0617;
+static const OffsetMap_t g_Offsets_v1_15_0610;
+static const OffsetMap_t g_Offsets_v1_15_0430;
+static const OffsetMap_t g_Offsets_v1_14_1227;
+
 static const OffsetMap_t g_Offsets_v1_14_1119 = {
 	{ ".plt:libusb_cancel_transfer",       0x046D30 },
 	{ ".text:callbackUSBTransferComplete", 0x1514D0 },
@@ -132,6 +142,11 @@ static const OffsetMap_t g_Offsets_v1_14_0715 = {
 	{ ".bss:lin_XferCallbacked",           0x3DD854 },
 };
 
+static const OffsetMap_t g_Offsets_v1_14_0425;
+static const OffsetMap_t g_Offsets_v1_14_0227;
+static const OffsetMap_t g_Offsets_v1_13_0930;
+static const OffsetMap_t g_Offsets_v1_13_0821;
+
 static const OffsetMap_t g_Offsets_v0_07_0503 = {
 	{ ".plt:libusb_cancel_transfer",       0x039588 },
 	{ ".text:callbackUSBTransferComplete", 0x0FB750 },
@@ -139,28 +154,34 @@ static const OffsetMap_t g_Offsets_v0_07_0503 = {
 	{ ".bss:lin_XferCallbacked",           0x37B8D4 },
 };
 
+static const OffsetMap_t g_Offsets_v0_07_0118;
+static const OffsetMap_t g_Offsets_v0_06_0921;
+static const OffsetMap_t g_Offsets_v0_06_0504;
+static const OffsetMap_t g_Offsets_v0_06_0414;
+static const OffsetMap_t g_Offsets_v0_06_0328;
+
 static const VersionMap_t g_KnownLibASIVersions = {
 	{ "1, 16, 3, 0", &g_Offsets_v1_16_3    }, // 2020-12-31
-	{ "1, 16, 2, 0", nullptr               }, // 2020-??-??
-	{ "1, 16, 1, 0", nullptr               }, // 2020-??-??
-	{ "1, 16, 0",    nullptr               }, // 2020-??-??
-	{ "1, 15, 0915", nullptr               }, // 2020-09-18
-	{ "1, 15, 0819", nullptr               }, // 2020-08-19-ish
-	{ "1, 15, 0617", nullptr               }, // 2020-06-17
-	{ "1, 15, 0610", nullptr               }, // 2020-06-10
-	{ "1, 15, 0430", nullptr               }, // 2020-04-30
+	{ "1, 16, 2, 0", &g_Offsets_v1_16_2    }, // 2020-??-??
+	{ "1, 16, 1, 0", &g_Offsets_v1_16_1    }, // 2020-??-??
+	{ "1, 16, 0",    &g_Offsets_v1_16_0    }, // 2020-??-??
+	{ "1, 15, 0915", &g_Offsets_v1_15_0915 }, // 2020-09-18
+	{ "1, 15, 0819", &g_Offsets_v1_15_0819 }, // 2020-08-19-ish
+	{ "1, 15, 0617", &g_Offsets_v1_15_0617 }, // 2020-06-17
+	{ "1, 15, 0610", &g_Offsets_v1_15_0610 }, // 2020-06-10
+	{ "1, 15, 0430", &g_Offsets_v1_15_0430 }, // 2020-04-30
 	{ "1, 14, 1119", &g_Offsets_v1_14_1119 }, // 2019-11-19
 	{ "1, 14, 0715", &g_Offsets_v1_14_0715 }, // 2019-07-15
-	{ "1, 14, 0425", nullptr               }, // 2019-04-25-ish
-	{ "1, 14, 0227", nullptr               }, // 2019-02-27
-	{ "1, 13, 0930", nullptr               }, // 2018-09-30
-	{ "1, 13, 0821", nullptr               }, // 2018-08-21
+	{ "1, 14, 0425", &g_Offsets_v1_14_0425 }, // 2019-04-25-ish
+	{ "1, 14, 0227", &g_Offsets_v1_14_0227 }, // 2019-02-27
+	{ "1, 13, 0930", &g_Offsets_v1_13_0930 }, // 2018-09-30
+	{ "1, 13, 0821", &g_Offsets_v1_13_0821 }, // 2018-08-21
 	{ "0,  7, 0503", &g_Offsets_v0_07_0503 }, // 2018-05-23 aka 1.13.0523
-	{ "0,  7, 0118", nullptr               }, // 2018-01-19 aka 1.13.1.12
-	{ "0,  6, 0921", nullptr               }, // 2017-09-21 aka 1.13.1.4
-	{ "0,  6, 0504", nullptr               }, // 2017-05-04 aka 1.13.?.?
-	{ "0,  6, 0414", nullptr               }, // 2017-04-14 aka 1.13.0.16
-	{ "0,  6, 0328", nullptr               }, // 2017-03-28 aka 1.13.0.13
+	{ "0,  7, 0118", &g_Offsets_v0_07_0118 }, // 2018-01-19 aka 1.13.1.12
+	{ "0,  6, 0921", &g_Offsets_v0_06_0921 }, // 2017-09-21 aka 1.13.1.4
+	{ "0,  6, 0504", &g_Offsets_v0_06_0504 }, // 2017-05-04 aka 1.13.?.?
+	{ "0,  6, 0414", &g_Offsets_v0_06_0414 }, // 2017-04-14 aka 1.13.0.16
+	{ "0,  6, 0328", &g_Offsets_v0_06_0328 }, // 2017-03-28 aka 1.13.0.13
 };
 
 static const dl_phdr_info *g_LibASIInfo    = nullptr;
@@ -211,7 +232,7 @@ static inline bool IsLibASILoadedAndSupported()
 						auto it = g_KnownLibASIVersions.find(g_LibASIVersion);
 						if (it != g_KnownLibASIVersions.end()) {
 							g_LibASIOffsets = it->second;
-							if (g_LibASIOffsets != nullptr) {
+							if (g_LibASIOffsets != nullptr && !g_LibASIOffsets->empty()) {
 								s_Supported = true;
 							} else {
 								Msg(Color::RED, "Init failure: library loaded, but version \"%s\" not supported\n", g_LibASIVersion);

--- a/zwo_fixer/internal.hpp
+++ b/zwo_fixer/internal.hpp
@@ -10,6 +10,61 @@
 // =============================================================================
 
 
+// OS and CPU Architecture =====================================================
+
+// Linux    x86    UNSUPPORTED (maybe later)
+// Linux    x64      SUPPORTED
+// Linux    ARMv5  UNSUPPORTED (maybe later)
+// Linux    ARMv6  UNSUPPORTED (maybe later)
+// Linux    ARMv7  UNSUPPORTED (maybe later)
+// Linux    ARMv8  UNSUPPORTED (soon)
+// Windows  x86    UNSUPPORTED (probably never)
+// Windows  x64    UNSUPPORTED (probably never)
+// MacOS    x86    UNSUPPORTED (probably never)
+// MacOS    x64    UNSUPPORTED (probably never)
+
+#if defined(__linux__)
+	#if defined(__i386__)
+		#define FIXER_X86 1
+		#warning zwo_fixer does not support the x86 architecture (yet)!
+		#warning functionality will be disabled!
+	#elif defined(__x86_64__)
+		#define FIXER_X64       1
+		#define FIXER_SUPPORTED 1
+	#elif defined(__arm__) && defined(__ARM_ARCH) && __ARM_ARCH == 5
+		#define FIXER_ARMV5 1
+		#warning zwo_fixer does not support the ARMv5 architecture (yet)!
+		#warning functionality will be disabled!
+	#elif defined(__arm__) && defined(__ARM_ARCH) && __ARM_ARCH == 6
+		#define FIXER_ARMV6 1
+		#warning zwo_fixer does not support the ARMv6 architecture (yet)!
+		#warning functionality will be disabled!
+	#elif defined(__arm__) && defined(__ARM_ARCH) && __ARM_ARCH == 7
+		#define FIXER_ARMV7 1
+		#warning zwo_fixer does not support the ARMv7 architecture (yet)!
+		#warning functionality will be disabled!
+	#elif defined(__aarch64__) && defined(__ARM_ARCH) && __ARM_ARCH == 8
+		#define FIXER_ARMV8     1
+		#warning zwo_fixer does not support the ARMv8 architecture (yet)!
+		#warning functionality will be disabled!
+	#else
+		#error zwo_fixer does not support whatever CPU architecture this is!
+	#endif
+#elif defined(__APPLE__)
+	#error zwo_fixer does not support the MacOS platform!
+#elif defined(_WIN32) || defined(_WIN64)
+	#error zwo_fixer does not support the Windows platform!
+#else
+	#error zwo_fixer does not support whatever platform this is!
+#endif
+
+#ifndef FIXER_SUPPORTED
+#define FIXER_SUPPORTED 0
+#endif
+
+// =============================================================================
+
+
 // Includes ====================================================================
 
 #ifndef _GNU_SOURCE
@@ -112,10 +167,12 @@ using OffsetMap_t  = std::unordered_map<std::string, uintptr_t>;
 using VersionMap_t = std::map<std::string, const OffsetMap_t *>;
 
 static const OffsetMap_t g_Offsets_v1_16_3 = {
+#if FIXER_X64
 	{ ".plt:libusb_cancel_transfer",       0x0516B0 },
 	{ ".text:callbackUSBTransferComplete", 0x187A20 },
 	{ ".data:lin_XferLen",                 0x3E7580 },
 	{ ".bss:lin_XferCallbacked",           0x437D14 },
+#endif
 };
 
 static const OffsetMap_t g_Offsets_v1_16_2;
@@ -129,17 +186,21 @@ static const OffsetMap_t g_Offsets_v1_15_0430;
 static const OffsetMap_t g_Offsets_v1_14_1227;
 
 static const OffsetMap_t g_Offsets_v1_14_1119 = {
+#if FIXER_X64
 	{ ".plt:libusb_cancel_transfer",       0x046D30 },
 	{ ".text:callbackUSBTransferComplete", 0x1514D0 },
 	{ ".data:lin_XferLen",                 0x3A1540 },
 	{ ".bss:lin_XferCallbacked",           0x3F1B74 },
+#endif
 };
 
 static const OffsetMap_t g_Offsets_v1_14_0715 = {
+#if FIXER_X64
 	{ ".plt:libusb_cancel_transfer",       0x043D28 },
 	{ ".text:callbackUSBTransferComplete", 0x1402E0 },
 	{ ".data:lin_XferLen",                 0x38D260 },
 	{ ".bss:lin_XferCallbacked",           0x3DD854 },
+#endif
 };
 
 static const OffsetMap_t g_Offsets_v1_14_0425;
@@ -148,10 +209,12 @@ static const OffsetMap_t g_Offsets_v1_13_0930;
 static const OffsetMap_t g_Offsets_v1_13_0821;
 
 static const OffsetMap_t g_Offsets_v0_07_0503 = {
+#if FIXER_X64
 	{ ".plt:libusb_cancel_transfer",       0x039588 },
 	{ ".text:callbackUSBTransferComplete", 0x0FB750 },
 	{ ".data:lin_XferLen",                 0x33F3E0 },
 	{ ".bss:lin_XferCallbacked",           0x37B8D4 },
+#endif
 };
 
 static const OffsetMap_t g_Offsets_v0_07_0118;

--- a/zwo_fixer/zwo_fixer.cpp
+++ b/zwo_fixer/zwo_fixer.cpp
@@ -50,7 +50,7 @@ when -EOVERFLOW happens:
 // This fixes that idiocy.
 PLTHook plthook__libusb_cancel_transfer(
 	"libusb_cancel_transfer",
-	GetAddr(".plt:libusb_cancel_transfer"),
+	GetAddr(".got.plt:libusb_cancel_transfer"),
 	+[](libusb_transfer *transfer) -> int {
 		int retval = libusb_cancel_transfer(transfer);
 		


### PR DESCRIPTION
I had a sudden realization after thinking about issue #50 for a little while, that the timeouts may actually have been happening due to libzwo_fixer screwing things up, *because apparently it was under the **very incorrect** presumption that everything was detected properly and that it was running on an AMD64 system, and was therefore patching in AMD64 hook code at undoubtedly incorrect/random addresses in the libASICamera2.so ARMv8 library!*

So, the first thing that needed correcting was to do proper architecture detection. Previously there was fairly rigorous detection of the ASI SDK version; however, nothing actually stopped the library from blissfully doing completely wrong things if it was running on a non-AMD64 machine. So now, there are preprocessor checks to categorize the machine the library is being compiled on, and either allow compilation to continue, or annoy the user with an error/warning message telling them that they're attempting to build for an architecture that doesn't actually have the necessary code support built in (including the actual offsets in the relevant platform's variation of the libASICamera2.so binary).

After that, I took a look at how the PLT is handled by the runtime dynamic linker on AArch64 vs how it's done on AMD64, and it's actually pretty similar. And given that it was trivial to locate the necessary offsets in the ARMv8 libASICamera2.so binary, I figured I would just go ahead and implement some multi-arch support into the library. So now it supports both AMD64 and ARMv8. (But not i386, ARMv5, ARMv6, ARMv7, or the Mac or Windows versions. The former four could probably be done pretty easily if the desire ever arose.)

Making the code simpler / more unified / more architecture-generic steered me toward altering the way I had been doing the PLT hooks. Previously I was doing a frankly somewhat boneheaded thing where I wrote a custom AMD64 asm stub over the PLT entry itself. I could have taken the same approach for ARMv8, but I'd have to do a separate asm implementation, and the ARM ISA instruction encoding is a gigantic pain in the ass (particularly because something ostensibly easy like "hey let's just load up a 64-bit immediate value into a register and then jump to it" requires like 7 steps because you can't fit very many bits into a fixed-size 32-bit instruction word). And there were other downsides too: the way I was doing it required me to flip the page protection flags on the memory whenever the hook was enabled or disabled, because the PLT stub itself is a code section with R-X permissions, and modifying the code requires RW-. (Oh and on ARM, unlike x86, doing self-modifying-code-type-stuff doesn't "just work", you have to actually explicitly make sure the L1 I$ and D$ synchronize properly and so forth.) Plus, I was doing some questionable things anyway like using memcpy to overwrite code, which is potentially problematic because there's no guarantee that memcpy isn't going to copy one byte at a time and temporarily put the code into a partially-overwritten state.

So now, I just take advantage of the fact that the PLT entries are already set to just do an indirect jump via their GOT PLT slot (which is in a data section that is already RW-), and I literally just do a single 64-bit atomic exchange operation to overwrite the pointer that's used for the indirect jump. I probably should have been doing this originally, but I think there were plausible reasons why I didn't want to do it. In any case, I think the new way is much simpler and less dumb overall.